### PR TITLE
Set the sources for node-gyp to avoid patching it.

### DIFF
--- a/Formula/iojs.rb
+++ b/Formula/iojs.rb
@@ -33,14 +33,19 @@ class Iojs < Formula
       ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
 
       cd buildpath/"npm_install" do
-        # Patch node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
-        # Patch extracted from https://github.com/iojs/io.js/commit/82227f3
-        p = Patch.create(:p1, :DATA)
-        p.path = Pathname.new(__FILE__).expand_path
-        p.apply
         system "./configure", "--prefix=#{libexec}/npm"
         system "make", "install"
       end
+
+      # Pre-download the sources for node-gyp until github.com/TooTallNate/node-gyp/pull/564 is resolved
+      if File.directory?("#{ENV['HOME']}/.node-gyp/#{version}")
+        system "rm", "-rf", "#{ENV['HOME']}/.node-gyp/#{version}"
+      end
+      system "mkdir", "-p", "#{ENV['HOME']}/.node-gyp/#{version}"
+      system "cp", "-a", "#{buildpath}/.", "#{ENV['HOME']}/.node-gyp/#{version}"
+      # mimick node-gyp version install. The number '9' has not changed since June 2012:
+      # https://github.com/TooTallNate/node-gyp/commit/569a9b2b4f55faa4347448058f6c4b2e791c3934
+      File.open("#{ENV['HOME']}/.node-gyp/#{version}/installVersion", 'w') {|f| f.write("9") }
 
       if build.with? "completion"
         bash_completion.install \
@@ -127,27 +132,3 @@ class Iojs < Formula
     end
   end
 end
-
-__END__
-diff --git a/node_modules/node-gyp/lib/install.js b/node_modules/node-gyp/lib/install.js
-index 6f72e6a..ebc4e57 100644
---- a/node_modules/node-gyp/lib/install.js
-+++ b/node_modules/node-gyp/lib/install.js
-@@ -39,7 +39,7 @@ function install (gyp, argv, callback) {
-     }
-   }
-
--  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'http://nodejs.org/dist'
-+  var distUrl = gyp.opts['dist-url'] || gyp.opts.disturl || 'https://iojs.org/dist'
-
-
-   // Determine which node dev files version we are installing
-@@ -185,7 +185,7 @@ function install (gyp, argv, callback) {
-
-       // now download the node tarball
-       var tarPath = gyp.opts['tarball']
--      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/node-v' + version + '.tar.gz'
-+      var tarballUrl = tarPath ? tarPath : distUrl + '/v' + version + '/iojs-v' + version + '.tar.gz'
-         , badDownload = false
-         , extractCount = 0
-         , gunzip = zlib.createGunzip()

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # homebrew-iojs
-A Homebrew formula for https://iojs.org.  Includes the following `iojs` compatibility patches to `npm`:
+A Homebrew formula for https://iojs.org.
 
-- https://github.com/iojs/io.js/commit/82227f3 deps: make node-gyp fetch tarballs from iojs.org
+Mimicks the execution of `node-gyp install`:
 
-> the patch is still compatible with joyent node: http://logs.libuv.org/npm/2015-01-28#21:53:34.823
+- Avoid re-downloading the iojs sources
+- Avoid patching node-gyp
+- Fully compatible with nodejs
 
 **NOTE**:  Work on the official homebrew `iojs` formula is ongoing. Follow [the progress here](https://github.com/Homebrew/homebrew/pull/36369)!
 


### PR DESCRIPTION
Hi everyone, would this alternative to patching node-gyp be acceptable for the mainstream homebrew?

Place the sources of nodejs/iojs into ~/.node-gyp/#{version} to avoid letting node-gyp download them.

Benefits:
- avoid re-downloading the sources at a later time. 
- compatible with iojs and nodejs.
- no patching of node-gyp.

Caveat: `node-gyp install` will fail.
