### PR TITLE
Add node-alt formula which installs a working node4

### DIFF
--- a/Aliases/node-alt
+++ b/Aliases/node-alt
@@ -1,0 +1,1 @@
+../Formula/node.rb

--- a/Formula/node.rb
+++ b/Formula/node.rb
@@ -1,0 +1,138 @@
+# Note that x.even are stable releases, x.odd are devel releases
+class Node < Formula
+  desc "Platform built on Chrome's JavaScript runtime to build network applications"
+  homepage "https://nodejs.org/"
+  url "https://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz"
+  sha256 "e110e5a066f3a6fe565ede7dd66f3727384b9b5c5fbf46f8db723d726e2f5900"
+  head "https://github.com/nodejs/node.git", :branch => "master"
+
+  option "with-debug", "Build with debugger hooks"
+  option "without-npm", "npm will not be installed"
+  option "without-completion", "npm bash completion will not be installed"
+
+  deprecated_option "enable-debug" => "with-debug"
+
+  depends_on :python => :build if MacOS.version <= :snow_leopard
+  depends_on "pkg-config" => :build
+  depends_on "openssl" => :optional
+
+  # https://github.com/nodejs/node-v0.x-archive/issues/7919
+  # https://github.com/Homebrew/homebrew/issues/36681
+  depends_on "icu4c" => :optional
+
+  fails_with :llvm do
+    build 2326
+  end
+
+  resource "npm" do
+    url "https://registry.npmjs.org/npm/-/npm-2.14.3.tgz"
+    sha256 "19755e14283977f713bb5115aea17d383cb0ca3f90db7c9f15146aad15f24c9b"
+  end
+
+  def install
+    args = %W[--prefix=#{prefix} --without-npm]
+    args << "--debug" if build.with? "debug"
+    args << "--with-intl=system-icu" if build.with? "icu4c"
+
+    if build.with? "openssl"
+      args << "--shared-openssl"
+    end
+
+    system "./configure", *args
+    system "make", "install"
+
+    if build.with? "npm"
+      resource("npm").stage buildpath/"npm_install"
+
+      # make sure npm can find node
+      ENV.prepend_path "PATH", bin
+      # set log level temporarily for npm's `make install`
+      ENV["NPM_CONFIG_LOGLEVEL"] = "verbose"
+
+      cd buildpath/"npm_install" do
+        system "./configure", "--prefix=#{libexec}/npm"
+        system "make", "install"
+      end
+
+      if build.with? "completion"
+        bash_completion.install \
+          buildpath/"npm_install/lib/utils/completion.sh" => "npm"
+      end
+    end
+  end
+
+  def post_install
+    return if build.without? "npm"
+
+    node_modules = HOMEBREW_PREFIX/"lib/node_modules"
+    node_modules.mkpath
+    npm_exec = node_modules/"npm/bin/npm-cli.js"
+    # Kill npm but preserve all other modules across node updates/upgrades.
+    rm_rf node_modules/"npm"
+
+    cp_r libexec/"npm/lib/node_modules/npm", node_modules
+    # This symlink doesn't hop into homebrew_prefix/bin automatically so
+    # remove it and make our own. This is a small consequence of our bottle
+    # npm make install workaround. All other installs **do** symlink to
+    # homebrew_prefix/bin correctly. We ln rather than cp this because doing
+    # so mimics npm's normal install.
+    ln_sf npm_exec, "#{HOMEBREW_PREFIX}/bin/npm"
+
+    # Let's do the manpage dance. It's just a jump to the left.
+    # And then a step to the right, with your hand on rm_f.
+    ["man1", "man3", "man5", "man7"].each do |man|
+      # Dirs must exist first: https://github.com/Homebrew/homebrew/issues/35969
+      mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
+      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.}*"]
+      ln_sf Dir[libexec/"npm/lib/node_modules/npm/man/#{man}/npm*"], HOMEBREW_PREFIX/"share/man/#{man}"
+    end
+
+    npm_root = node_modules/"npm"
+    npmrc = npm_root/"npmrc"
+    npmrc.atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  def caveats
+    s = ""
+
+    if build.without? "npm"
+      s += <<-EOS.undent
+        Homebrew has NOT installed npm. If you later install it, you should supplement
+        your NODE_PATH with the npm module folder:
+          #{HOMEBREW_PREFIX}/lib/node_modules
+      EOS
+    end
+
+    if build.with? "icu4c"
+      s += <<-EOS.undent
+
+        Please note `icu4c` is built with a newer deployment target than Node and
+        this may cause issues in certain usage. Node itself is built against the
+        outdated `libstdc++` target, which is the root cause. For more information see:
+          https://github.com/nodejs/node-v0.x-archive/issues/7919
+
+        If this is an issue for you, do `brew install node --without-icu4c`.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+
+    output = `#{bin}/node #{path}`.strip
+    assert_equal "hello", output
+    assert_equal 0, $?.exitstatus
+
+    if build.with? "npm"
+      # make sure npm can find node
+      ENV.prepend_path "PATH", opt_bin
+      assert_equal which("node"), opt_bin/"node"
+      assert (HOMEBREW_PREFIX/"bin/npm").exist?, "npm must exist"
+      assert (HOMEBREW_PREFIX/"bin/npm").executable?, "npm must be executable"
+      system "#{HOMEBREW_PREFIX}/bin/npm", "--verbose", "install", "npm@latest"
+    end
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # homebrew-iojs
+
 A Homebrew formula for https://iojs.org.  Includes the following `iojs` compatibility patches to `npm`:
 
 - https://github.com/iojs/io.js/commit/82227f3 deps: make node-gyp fetch tarballs from iojs.org
@@ -25,3 +26,15 @@ brew link aredridel/iojs/iojs
 ```
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://github.com/Homebrew/homebrew/tree/master/share/doc/homebrew#readme).
+
+## Node 4+
+
+Now including a Node 4+ formula!
+
+```
+$ brew update
+$ brew install node-alt
+```
+
+Node, this is just an alias to this tap's node formula and will install in place of the offical homebrew formula.
+


### PR DESCRIPTION
We can maintain this until homebrew supports new releases of node in a practical way.

Basic usage is included in the readme, but basically you install the new alias:

```
$ brew install node-alt
```

This is an alias to the taps node formula and will install over the node formula namespace.

I went ahead and bundled npm 2.14.3 to avoid having to float patches for the rest of the week :+1: 

Let me know what y'all think!
